### PR TITLE
Fixes tests for release.js

### DIFF
--- a/lib/test/releases.test.js
+++ b/lib/test/releases.test.js
@@ -203,8 +203,8 @@ describe('getRelease', () => {
 
   it.each(
     [
-      ['foo', 'Input version cannot be used, see semver: https://semver.org/spec/v2.0.0.html', undefined],
-      ['2.0', 'No matching version found', undefined],
+      ['foo', 'Input version cannot be used, see semver: https://semver.org/spec/v2.0.0.html', mockFetchReleases],
+      ['2.0', 'No matching version found', mockFetchReleases],
       ['latest', 'No tofu releases found, please contact OpenTofu', async () => { return null; }],
       ['latest', 'No tofu releases found, please contact OpenTofu', async () => { return []; }]
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-opentofu",
-  "version": "0.0.1",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-opentofu",
-      "version": "0.0.1",
+      "version": "1.0.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@actions/core": "1.10.1",
@@ -19,7 +19,6 @@
         "@vercel/ncc": "0.38.1",
         "husky": "8.0.3",
         "jest": "29.7.0",
-        "nock": "13.3.6",
         "semistandard": "17.0.0"
       }
     },
@@ -4525,12 +4524,6 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -4774,20 +4767,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
-    },
-    "node_modules/nock": {
-      "version": "13.3.6",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.6.tgz",
-      "integrity": "sha512-lT6YuktKroUFM+27mubf2uqQZVy2Jf+pfGzuh9N6VwdHlFoZqvi4zyxFTVR1w/ChPqGY6yxGehHp6C3wqCASCw==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.0",
-        "json-stringify-safe": "^5.0.1",
-        "propagate": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13"
-      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5261,15 +5261,6 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
-    "node_modules/propagate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
-      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-opentofu",
-  "version": "0.0.1",
+  "version": "1.0.1",
   "description": "Setup OpenTofu CLI for GitHub Actions",
   "license": "MPL-2.0",
   "publisher": "OpenTofu",
@@ -29,7 +29,6 @@
     "@vercel/ncc": "0.38.1",
     "husky": "8.0.3",
     "jest": "29.7.0",
-    "nock": "13.3.6",
     "semistandard": "17.0.0"
   },
   "semistandard": {


### PR DESCRIPTION
Resolved #13 

## What changed

- Fixed fetchReleases stub's use
- Removed unused dev dependency
- Updates the project.json version

## Why do we need it

To avoid unessesarily github API calls to prevent flaky CI tests.
