### PR TITLE
Add `shell: bash` to `defaults: run`

### DIFF
--- a/.github/workflows/setup-tofu.yml
+++ b/.github/workflows/setup-tofu.yml
@@ -80,6 +80,7 @@ jobs:
         tofu-wrapper: [true, false]
     defaults:
       run:
+        shell: bash
         working-directory: ./.github/workflows/data/local
     steps:
     - name: Checkout


### PR DESCRIPTION
This PR adds `shell: bash` to `defaults: run` of "terraform-run-local" job.

Even though we have specified `defaults: run: shell: bash` at the top-level, this is unset if `defaults: run:` is re-defined at the job-level. As a result, adding `shell: bash` ensures consistency with expectation of the default command shell. 