### PR TITLE
Added input parameter for ACTIONS_STEP_DEBUG

### DIFF
--- a/.github/workflows/setup-tofu.yml
+++ b/.github/workflows/setup-tofu.yml
@@ -5,6 +5,13 @@ on:
     branches:
     - main
   pull_request:
+  workflow_dispatch:
+    inputs:
+      debug:
+        description: 'Enable debug logs for steps'
+        type: boolean
+        required: false
+        default: false
 
 defaults:
   run:
@@ -27,6 +34,8 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Setup OpenTofu - ${{ matrix['tofu-versions'] }}
+      env: 
+        ACTIONS_STEP_DEBUG: ${{ inputs.debug }}
       uses: ./
       with:
         tofu_version: ${{ matrix['tofu-versions'] }}
@@ -50,6 +59,8 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Setup OpenTofu
+      env: 
+        ACTIONS_STEP_DEBUG: ${{ inputs.debug }}
       uses: ./
       with:
         tofu_wrapper: ${{ matrix['tofu-wrapper'] }}
@@ -73,6 +84,8 @@ jobs:
       run: tofu fmt -check -list=true -no-color
   tofu-run-local:
     name: 'OpenTofu Run Local'
+    env: 
+      ACTIONS_STEP_DEBUG: ${{ inputs.debug }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -112,6 +125,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     env:
       TF_CLOUD_API_TOKEN: 'XXXXXXXXXXXXXX.atlasv1.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+      ACTIONS_STEP_DEBUG: ${{ inputs.debug }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -141,6 +155,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     env:
       TF_CLOUD_API_TOKEN: 'XXXXXXXXXXXXXX.atlasv1.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+      ACTIONS_STEP_DEBUG: ${{ inputs.debug }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -165,6 +180,8 @@ jobs:
 
   tofu-credentials-none:
     name: 'OpenTofu No Credentials'
+    env: 
+      ACTIONS_STEP_DEBUG: ${{ inputs.debug }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Objective: Make debugging logs optional.

Changes: 
- Added input parameter `debug` whose default value is set to false.
- Added environment variable `ACTIONS_STEP_DEBUG` in all the `Setup OpenTofu` steps to enable/disable step debug logging. (reference: [Github Docs](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging))

Resolves: #6 