### PR TITLE
Fix tofu output printing debug information

### DIFF
--- a/dist/index1.js
+++ b/dist/index1.js
@@ -4210,13 +4210,14 @@ async function checkTofu () {
   const args = process.argv.slice(2);
   const options = {
     listeners,
-    ignoreReturnCode: true
+    ignoreReturnCode: true,
+    silent: true // don't print "[command...]" into stdout: https://github.com/actions/toolkit/issues/649
   };
   const exitCode = await exec(pathToCLI, args, options);
-  core.debug(`OpenTofu exited with code ${exitCode}.`);
-  core.debug(`stdout: ${stdout.contents}`);
-  core.debug(`stderr: ${stderr.contents}`);
-  core.debug(`exitcode: ${exitCode}`);
+
+  // Pass-through stdout/err as `exec` won't due to `silent: true` option
+  process.stdout.write(stdout.contents);
+  process.stderr.write(stderr.contents);
 
   // Set outputs, result, exitcode, and stderr
   core.setOutput('stdout', stdout.contents);

--- a/wrapper/tofu.js
+++ b/wrapper/tofu.js
@@ -33,13 +33,14 @@ async function checkTofu () {
   const args = process.argv.slice(2);
   const options = {
     listeners,
-    ignoreReturnCode: true
+    ignoreReturnCode: true,
+    silent: true // don't print "[command...]" into stdout: https://github.com/actions/toolkit/issues/649
   };
   const exitCode = await exec(pathToCLI, args, options);
-  core.debug(`OpenTofu exited with code ${exitCode}.`);
-  core.debug(`stdout: ${stdout.contents}`);
-  core.debug(`stderr: ${stderr.contents}`);
-  core.debug(`exitcode: ${exitCode}`);
+
+  // Pass-through stdout/err as `exec` won't due to `silent: true` option
+  process.stdout.write(stdout.contents);
+  process.stderr.write(stderr.contents);
 
   // Set outputs, result, exitcode, and stderr
   core.setOutput('stdout', stdout.contents);


### PR DESCRIPTION
After looking around a bit I found the wrapper part where the debug is printed out. I also compared the Terraform setup and OpenTofu setup code, and found out how they actually fixed it. I tested the fix myself and saw that the debug was removed.

Before:
![image](https://github.com/opentofu/setup-opentofu/assets/28529900/ef5011a3-413c-4990-8040-286d06ce70dd)


After:
![image](https://github.com/opentofu/setup-opentofu/assets/28529900/7c6a297e-cd03-42c8-bfff-23fd5bf15d47)

Closes #6 #18 
I am not sure what to do about #28 