### PR TITLE
feat(acc): Add provider_acceptance_tests input for automated acceptance test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,14 @@ steps:
     cache: true
 ```
 
-Provider acceptance test environment variables can be configured automatically by setting `provider_acceptance_test` to `true`. This exports `TF_ACC`, `TF_ACC_PROVIDER_NAMESPACE`, `TF_ACC_PROVIDER_HOST`, and `TF_ACC_TERRAFORM_PATH` so you don't need to set them manually:
+Provider acceptance test environment variables can be configured automatically by setting `provider_acceptance_tests` to `true`. This exports `TF_ACC`, `TF_ACC_PROVIDER_NAMESPACE`, `TF_ACC_PROVIDER_HOST`, and `TF_ACC_TERRAFORM_PATH` so you don't need to set them manually:
 
 ```yaml
 steps:
 - uses: opentofu/setup-opentofu@v2
   with:
     tofu_wrapper: false
-    provider_acceptance_test: true
+    provider_acceptance_tests: true
 - run: go mod download
 - run: go test -v -cover ./...
   timeout-minutes: 10
@@ -298,7 +298,7 @@ The action supports the following inputs:
   the `tofu` binary and expose its STDOUT, STDERR, and exit code as outputs
   named `stdout`, `stderr`, and `exitcode` respectively. Defaults to `true`.
 - `cache` - (optional) Whether to use GitHub Actions tool-cache to store and reuse downloaded OpenTofu binaries. Defaults to `false`.
-- `provider_acceptance_test` - (optional) Whether to automatically set environment variables for running
+- `provider_acceptance_tests` - (optional) Whether to automatically set environment variables for running
   OpenTofu provider acceptance tests. When set to `true`, the following environment variables are exported:
   `TF_ACC=1`, `TF_ACC_PROVIDER_NAMESPACE=hashicorp`, `TF_ACC_PROVIDER_HOST=registry.opentofu.org`, and
   `TF_ACC_TERRAFORM_PATH=<path to tofu binary>`. Defaults to `false`.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,19 @@ steps:
     cache: true
 ```
 
+Provider acceptance test environment variables can be configured automatically by setting `provider_acceptance_test` to `true`. This exports `TF_ACC`, `TF_ACC_PROVIDER_NAMESPACE`, `TF_ACC_PROVIDER_HOST`, and `TF_ACC_TERRAFORM_PATH` so you don't need to set them manually:
+
+```yaml
+steps:
+- uses: opentofu/setup-opentofu@v1
+  with:
+    tofu_wrapper: false
+    provider_acceptance_test: true
+- run: go mod download
+- run: go test -v -cover ./...
+  timeout-minutes: 10
+```
+
 Subsequent steps can access outputs when the wrapper script is installed:
 
 ```yaml
@@ -274,6 +287,10 @@ The action supports the following inputs:
   the `tofu` binary and expose its STDOUT, STDERR, and exit code as outputs
   named `stdout`, `stderr`, and `exitcode` respectively. Defaults to `true`.
 - `cache` - (optional) Whether to use GitHub Actions tool-cache to store and reuse downloaded OpenTofu binaries. Defaults to `false`.
+- `provider_acceptance_test` - (optional) Whether to automatically set environment variables for running
+  OpenTofu provider acceptance tests. When set to `true`, the following environment variables are exported:
+  `TF_ACC=1`, `TF_ACC_PROVIDER_NAMESPACE=hashicorp`, `TF_ACC_PROVIDER_HOST=registry.opentofu.org`, and
+  `TF_ACC_TERRAFORM_PATH=<path to tofu binary>`. Defaults to `false`.
 - `github_token` - (optional) Override the GitHub token read from the environment variable. Defaults to the value of the `GITHUB_TOKEN` environment variable unless running on Forgejo or Gitea.
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
     description: 'API token for GitHub to increase the rate limit. Defaults to the GITHUB_TOKEN environment variable unless running on Forgejo/Gitea.'
     default: ''
     required: false
-  provider_acceptance_test:
+  provider_acceptance_tests:
     description: 'Whether to automatically set environment variables for running OpenTofu provider acceptance tests (TF_ACC, TF_ACC_PROVIDER_NAMESPACE, TF_ACC_PROVIDER_HOST, TF_ACC_TERRAFORM_PATH). Defaults to `false`.'
     default: 'false'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: 'API token for GitHub to increase the rate limit. Defaults to the GITHUB_TOKEN environment variable unless running on Forgejo/Gitea.'
     default: ''
     required: false
+  provider_acceptance_test:
+    description: 'Whether to automatically set environment variables for running OpenTofu provider acceptance tests (TF_ACC, TF_ACC_PROVIDER_NAMESPACE, TF_ACC_PROVIDER_HOST, TF_ACC_TERRAFORM_PATH). Defaults to `false`.'
+    default: 'false'
+    required: false
 outputs:
   stdout:
     description: 'The STDOUT stream of the call to the `tofu` binary.'

--- a/dist/index.js
+++ b/dist/index.js
@@ -34776,6 +34776,7 @@ async function run () {
     const credentialsHostname = getInput('cli_config_credentials_hostname');
     const credentialsToken = getInput('cli_config_credentials_token');
     const wrapper = getInput('tofu_wrapper') === 'true';
+    const providerAcceptanceTest = getInput('provider_acceptance_test') === 'true';
     const useCache = getInput('cache') === 'true';
     let githubToken = getInput('github_token');
     if (
@@ -34847,6 +34848,16 @@ async function run () {
 
     // Add to path
     addPath(pathToCLI);
+
+    // Set up provider acceptance test environment variables
+    if (providerAcceptanceTest) {
+      const exeSuffix = (0,external_os_namespaceObject.platform)().startsWith('win') ? '.exe' : '';
+      const binaryName = wrapper ? `tofu-bin${exeSuffix}` : `tofu${exeSuffix}`;
+      exportVariable('TF_ACC', '1');
+      exportVariable('TF_ACC_PROVIDER_NAMESPACE', 'hashicorp');
+      exportVariable('TF_ACC_PROVIDER_HOST', 'registry.opentofu.org');
+      exportVariable('TF_ACC_TERRAFORM_PATH', (0,external_path_namespaceObject.join)(pathToCLI, binaryName));
+    }
 
     // Add credentials to file if they are provided
     if (credentialsHostname && credentialsToken) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -34811,7 +34811,7 @@ async function run () {
     const credentialsHostname = getInput('cli_config_credentials_hostname');
     const credentialsToken = getInput('cli_config_credentials_token');
     const wrapper = getInput('tofu_wrapper') === 'true';
-    const providerAcceptanceTest = getInput('provider_acceptance_test') === 'true';
+    const providerAcceptanceTest = getInput('provider_acceptance_tests') === 'true';
     const useCache = getInput('cache') === 'true';
     const checksums = getMultilineInput('checksums');
     let githubToken = getInput('github_token');

--- a/lib/setup-tofu.js
+++ b/lib/setup-tofu.js
@@ -7,7 +7,7 @@
 // Node.js core
 import { promises as fs } from 'fs';
 import { platform, arch } from 'os';
-import { sep, resolve, dirname } from 'path';
+import { sep, join, resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 // External
@@ -161,6 +161,7 @@ async function run () {
     const credentialsHostname = getInput('cli_config_credentials_hostname');
     const credentialsToken = getInput('cli_config_credentials_token');
     const wrapper = getInput('tofu_wrapper') === 'true';
+    const providerAcceptanceTest = getInput('provider_acceptance_test') === 'true';
     const useCache = getInput('cache') === 'true';
     let githubToken = getInput('github_token');
     if (
@@ -232,6 +233,16 @@ async function run () {
 
     // Add to path
     addPath(pathToCLI);
+
+    // Set up provider acceptance test environment variables
+    if (providerAcceptanceTest) {
+      const exeSuffix = platform().startsWith('win') ? '.exe' : '';
+      const binaryName = wrapper ? `tofu-bin${exeSuffix}` : `tofu${exeSuffix}`;
+      exportVariable('TF_ACC', '1');
+      exportVariable('TF_ACC_PROVIDER_NAMESPACE', 'hashicorp');
+      exportVariable('TF_ACC_PROVIDER_HOST', 'registry.opentofu.org');
+      exportVariable('TF_ACC_TERRAFORM_PATH', join(pathToCLI, binaryName));
+    }
 
     // Add credentials to file if they are provided
     if (credentialsHostname && credentialsToken) {

--- a/lib/setup-tofu.js
+++ b/lib/setup-tofu.js
@@ -177,7 +177,7 @@ async function run () {
     const credentialsHostname = getInput('cli_config_credentials_hostname');
     const credentialsToken = getInput('cli_config_credentials_token');
     const wrapper = getInput('tofu_wrapper') === 'true';
-    const providerAcceptanceTest = getInput('provider_acceptance_test') === 'true';
+    const providerAcceptanceTest = getInput('provider_acceptance_tests') === 'true';
     const useCache = getInput('cache') === 'true';
     const checksums = getMultilineInput('checksums');
     let githubToken = getInput('github_token');

--- a/lib/test/setup-tofu.test.js
+++ b/lib/test/setup-tofu.test.js
@@ -42,7 +42,7 @@ jest.unstable_mockModule('../releases.js', () => ({
 }));
 
 // Dynamic imports pick up the mocks
-const { getInput, warning } = await import('@actions/core');
+const { getInput, warning, exportVariable } = await import('@actions/core');
 const tc = await import('@actions/tool-cache');
 const io = await import('@actions/io');
 const { getRelease } = await import('../releases.js');
@@ -88,6 +88,7 @@ describe('setup-tofu', () => {
         cli_config_credentials_hostname: '',
         cli_config_credentials_token: '',
         tofu_wrapper: 'true',
+        provider_acceptance_test: 'false',
         cache: 'false',
         github_token: ''
       };
@@ -264,6 +265,7 @@ describe('setup-tofu', () => {
           cli_config_credentials_hostname: '',
           cli_config_credentials_token: '',
           tofu_wrapper: 'true',
+          provider_acceptance_test: 'false',
           cache: 'false',
           github_token: ''
         };
@@ -276,6 +278,87 @@ describe('setup-tofu', () => {
       expect(tc.downloadTool).toHaveBeenCalled();
       expect(tc.extractZip).toHaveBeenCalled();
       expect(tc.cacheDir).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('provider_acceptance_test functionality', () => {
+    it('should export acceptance test env vars when enabled without wrapper', async () => {
+      getInput.mockImplementation((name) => {
+        const defaults = {
+          tofu_version: fallbackVersion,
+          tofu_version_file: '',
+          cli_config_credentials_hostname: '',
+          cli_config_credentials_token: '',
+          tofu_wrapper: 'false',
+          provider_acceptance_test: 'true',
+          cache: 'false',
+          github_token: ''
+        };
+        return defaults[name] || '';
+      });
+
+      await setup();
+
+      expect(exportVariable).toHaveBeenCalledWith('TF_ACC', '1');
+      expect(exportVariable).toHaveBeenCalledWith('TF_ACC_PROVIDER_NAMESPACE', 'hashicorp');
+      expect(exportVariable).toHaveBeenCalledWith('TF_ACC_PROVIDER_HOST', 'registry.opentofu.org');
+      expect(exportVariable).toHaveBeenCalledWith(
+        'TF_ACC_TERRAFORM_PATH',
+        expect.stringContaining('tofu')
+      );
+      expect(exportVariable).not.toHaveBeenCalledWith(
+        'TF_ACC_TERRAFORM_PATH',
+        expect.stringContaining('tofu-bin')
+      );
+    });
+
+    it('should point TF_ACC_TERRAFORM_PATH to tofu-bin when wrapper is enabled', async () => {
+      getInput.mockImplementation((name) => {
+        const defaults = {
+          tofu_version: fallbackVersion,
+          tofu_version_file: '',
+          cli_config_credentials_hostname: '',
+          cli_config_credentials_token: '',
+          tofu_wrapper: 'true',
+          provider_acceptance_test: 'true',
+          cache: 'false',
+          github_token: ''
+        };
+        return defaults[name] || '';
+      });
+
+      await setup();
+
+      expect(exportVariable).toHaveBeenCalledWith('TF_ACC', '1');
+      expect(exportVariable).toHaveBeenCalledWith('TF_ACC_PROVIDER_NAMESPACE', 'hashicorp');
+      expect(exportVariable).toHaveBeenCalledWith('TF_ACC_PROVIDER_HOST', 'registry.opentofu.org');
+      expect(exportVariable).toHaveBeenCalledWith(
+        'TF_ACC_TERRAFORM_PATH',
+        expect.stringContaining('tofu-bin')
+      );
+    });
+
+    it('should not export acceptance test env vars when disabled', async () => {
+      getInput.mockImplementation((name) => {
+        const defaults = {
+          tofu_version: fallbackVersion,
+          tofu_version_file: '',
+          cli_config_credentials_hostname: '',
+          cli_config_credentials_token: '',
+          tofu_wrapper: 'false',
+          provider_acceptance_test: 'false',
+          cache: 'false',
+          github_token: ''
+        };
+        return defaults[name] || '';
+      });
+
+      await setup();
+
+      expect(exportVariable).not.toHaveBeenCalledWith('TF_ACC', expect.anything());
+      expect(exportVariable).not.toHaveBeenCalledWith('TF_ACC_PROVIDER_NAMESPACE', expect.anything());
+      expect(exportVariable).not.toHaveBeenCalledWith('TF_ACC_PROVIDER_HOST', expect.anything());
+      expect(exportVariable).not.toHaveBeenCalledWith('TF_ACC_TERRAFORM_PATH', expect.anything());
     });
   });
 });

--- a/lib/test/setup-tofu.test.js
+++ b/lib/test/setup-tofu.test.js
@@ -94,7 +94,7 @@ describe('setup-tofu', () => {
         cli_config_credentials_hostname: '',
         cli_config_credentials_token: '',
         tofu_wrapper: 'true',
-        provider_acceptance_test: 'false',
+        provider_acceptance_tests: 'false',
         cache: 'false',
         github_token: ''
       };
@@ -278,7 +278,7 @@ describe('setup-tofu', () => {
           cli_config_credentials_hostname: '',
           cli_config_credentials_token: '',
           tofu_wrapper: 'true',
-          provider_acceptance_test: 'false',
+          provider_acceptance_tests: 'false',
           cache: 'false',
           github_token: ''
         };
@@ -294,7 +294,7 @@ describe('setup-tofu', () => {
     });
   });
 
-  describe('provider_acceptance_test functionality', () => {
+  describe('provider_acceptance_tests functionality', () => {
     it('should export acceptance test env vars when enabled without wrapper', async () => {
       getInput.mockImplementation((name) => {
         const defaults = {
@@ -303,7 +303,7 @@ describe('setup-tofu', () => {
           cli_config_credentials_hostname: '',
           cli_config_credentials_token: '',
           tofu_wrapper: 'false',
-          provider_acceptance_test: 'true',
+          provider_acceptance_tests: 'true',
           cache: 'false',
           github_token: ''
         };
@@ -333,7 +333,7 @@ describe('setup-tofu', () => {
           cli_config_credentials_hostname: '',
           cli_config_credentials_token: '',
           tofu_wrapper: 'true',
-          provider_acceptance_test: 'true',
+          provider_acceptance_tests: 'true',
           cache: 'false',
           github_token: ''
         };
@@ -359,7 +359,7 @@ describe('setup-tofu', () => {
           cli_config_credentials_hostname: '',
           cli_config_credentials_token: '',
           tofu_wrapper: 'false',
-          provider_acceptance_test: 'false',
+          provider_acceptance_tests: 'false',
           cache: 'false',
           github_token: ''
         };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1115,9 +1115,9 @@
 			}
 		},
 		"node_modules/@jest/reporters/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+			"integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2217,9 +2217,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+			"integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4546,9 +4546,9 @@
 			}
 		},
 		"node_modules/jest-config/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+			"integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4880,9 +4880,9 @@
 			}
 		},
 		"node_modules/jest-runtime/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+			"integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {


### PR DESCRIPTION
resolves #36 

Used https://github.com/orgs/opentofu/discussions/975 as a framework for decisions.

Adds a new provider_acceptance_tests input that, when set to true, automatically exports the environment variables needed to run OpenTofu provider acceptance tests. This removes boilerplate from CI workflows that run provider acceptance tests.


