### PR TITLE
Feature: Implement checksum validation logic in setup-tofu

### DIFF
--- a/lib/setup-tofu.js
+++ b/lib/setup-tofu.js
@@ -9,6 +9,7 @@ import { promises as fs } from 'fs';
 import { platform, arch } from 'os';
 import { sep, resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { createHash } from 'crypto';
 
 // External
 import {
@@ -46,7 +47,7 @@ function mapOS (os) {
   return os;
 }
 
-async function downloadAndExtractCLI (url) {
+async function downloadAndExtractCLI (url, expectedChecksum) {
   debug(`Downloading OpenTofu CLI from ${url}`);
   let pathToCLIZip;
   try {
@@ -58,6 +59,22 @@ async function downloadAndExtractCLI (url) {
 
   if (!pathToCLIZip) {
     throw new Error(`Unable to download OpenTofu from ${url}`);
+  }
+
+  if (expectedChecksum) {
+    debug('Verifying SHA-256 checksum for downloaded file');
+    let computedChecksum;
+    try {
+      const fileBuffer = await fs.readFile(pathToCLIZip);
+      computedChecksum = createHash('sha256').update(fileBuffer).digest('hex');
+    } catch (error) {
+      const cause = getErrorMessage(error);
+      throw new Error(`Failed to compute checksum for ${url}: ${cause}`);
+    }
+    if (computedChecksum !== expectedChecksum) {
+      throw new Error(`Checksum mismatch: expected ${expectedChecksum} but got ${computedChecksum}`);
+    }
+    debug(`Checksum verified successfully: ${computedChecksum}`);
   }
 
   let pathToCLI;
@@ -162,6 +179,7 @@ async function run () {
     const credentialsToken = getInput('cli_config_credentials_token');
     const wrapper = getInput('tofu_wrapper') === 'true';
     const useCache = getInput('cache') === 'true';
+    const checksums = getInput('checksums');
     let githubToken = getInput('github_token');
     if (
       githubToken === '' &&
@@ -217,12 +235,12 @@ async function run () {
         pathToCLI = cachedPath;
       } else {
         debug(`OpenTofu version ${release.version} not found in cache, downloading...`);
-        const extractedPath = await downloadAndExtractCLI(build.url);
+        const extractedPath = await downloadAndExtractCLI(build.url, checksums);
         debug(`Caching OpenTofu version ${release.version} to tool cache`);
         pathToCLI = await cacheDir(extractedPath, 'tofu', release.version, buildArch);
       }
     } else {
-      pathToCLI = await downloadAndExtractCLI(build.url);
+      pathToCLI = await downloadAndExtractCLI(build.url, checksums);
     }
 
     // Install our wrapper


### PR DESCRIPTION
## Description

Add support for parsing the `checksums` input, computing SHA-256 of the downloaded zip, and comparing it against the user-supplied value. Update `downloadAndExtractCLI` to accept and perform verification before extraction.

## Changes

- `lib/setup-tofu.js` (modified)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Code follows the style guidelines of this project
- [x] Self-review of code completed
- [x] Changes generate no new warnings
- [ ] Corresponding changes to documentation made (if applicable)

**Severity**: `critical`


Closes #100