### PR TITLE
Feature: Make exit code handling configurable via TOFU_WRAPPER_IGNORE_EXIT_CODES

### DIFF
--- a/wrapper/tofu.js
+++ b/wrapper/tofu.js
@@ -12,6 +12,11 @@ import { exec } from '@actions/exec';
 import OutputListener from './lib/output-listener.js';
 import pathToCLI from './lib/tofu-bin.js';
 
+const ignoreExitCodes = (process.env.TOFU_WRAPPER_IGNORE_EXIT_CODES || '')
+  .split(',')
+  .map((c) => parseInt(c.trim(), 10))
+  .filter((c) => !isNaN(c));
+
 async function checkTofu () {
   // Setting check to `true` will cause `which` to throw if tofu isn't found
   const check = true;
@@ -44,7 +49,7 @@ async function checkTofu () {
   setOutput('stderr', stderr.contents);
   setOutput('exitcode', exitCode.toString(10));
 
-  if (exitCode === 0 || exitCode === 2) {
+  if (exitCode === 0 || ignoreExitCodes.includes(exitCode)) {
     // A exitCode of 0 is considered a success
     // An exitCode of 2 may be returned when the '-detailed-exitcode' option
     // is passed to plan. This denotes Success with non-empty


### PR DESCRIPTION
## Description

Remove the hard-coded exception for exit code 2 that prevents job failure on errors. Instead, read the TOFU_WRAPPER_IGNORE_EXIT_CODES environment variable (comma-separated list of integer codes). By default the list is empty, meaning any non-zero exit code will cause the wrapper to call setFailed() (or equivalent) so the GitHub Actions job fails. This matches the issue's requirement that ignoring exit codes should be an explicit user choice.

## Changes

- `wrapper/tofu.js` (modified)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Code follows the style guidelines of this project
- [x] Self-review of code completed
- [x] Changes generate no new warnings
- [ ] Corresponding changes to documentation made (if applicable)

**Severity**: `high`


Closes #101