### PR TITLE
feat(releases): retry fetchReleases on transient failures with backoff

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -34503,12 +34503,51 @@ class Release {
   }
 }
 
+const FETCH_RELEASES_MAX_ATTEMPTS = 4;
+const FETCH_RELEASES_BASE_DELAY_MS = 500;
+const FETCH_RELEASES_MAX_DELAY_MS = 8000;
+
+// Status codes that are worth retrying. Transient per GitHub's guidance
+// (https://docs.github.com/en/rest/overview/resources-in-the-rest-api#abuse-rate-limits)
+// and general HTTP semantics for 5xx / 408 Request Timeout / 429 Too Many Requests.
+const RETRYABLE_STATUS_CODES = new Set([
+  HttpCodes.RequestTimeout,
+  HttpCodes.TooManyRequests,
+  HttpCodes.InternalServerError,
+  HttpCodes.BadGateway,
+  HttpCodes.ServiceUnavailable,
+  HttpCodes.GatewayTimeout
+]);
+
+function _sleep (ms) {
+  return new Promise((resolve) => { setTimeout(resolve, ms); });
+}
+
+function _backoffDelayMs (attempt) {
+  // Exponential backoff: 500ms, 1s, 2s, 4s, ... capped at 8s, with jitter up to 250ms
+  // so multiple concurrent runners don't resync on the same retry boundary.
+  const exponential = Math.min(
+    FETCH_RELEASES_BASE_DELAY_MS * Math.pow(2, attempt),
+    FETCH_RELEASES_MAX_DELAY_MS
+  );
+  const jitter = Math.floor(Math.random() * 250);
+  return exponential + jitter;
+}
+
 /**
  * Fetches the top 30 releases sorted in desc order.
  *
+ * Retries transient failures (network errors, 408/429/5xx responses) with
+ * exponential backoff + jitter. Permanent failures (4xx other than 408/429,
+ * malformed JSON) fail fast on the first attempt.
+ *
  * @return {Array<Release>} Releases.
  */
-async function fetchReleases (githubToken) {
+async function fetchReleases (githubToken, {
+  maxAttempts = FETCH_RELEASES_MAX_ATTEMPTS,
+  sleepFn = _sleep,
+  backoffFn = _backoffDelayMs
+} = {}) {
   const userAgent = 'opentofu/setup-opentofu';
 
   const http = new lib_HttpClient(userAgent);
@@ -34519,42 +34558,71 @@ async function fetchReleases (githubToken) {
     Accept: 'application/json'
   };
 
-  let resp;
-  try {
-    resp = await http.get(url, headers);
-  } catch (error) {
-    const cause = getErrorMessage(error);
-    throw new Error(`Failed to fetch OpenTofu releases from ${url}: ${cause}`);
+  let lastError;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    let resp;
+    try {
+      resp = await http.get(url, headers);
+    } catch (error) {
+      // Network-level failure -- always retryable; fall through to backoff.
+      lastError = new Error(
+        `Failed to fetch OpenTofu releases from ${url}: ${getErrorMessage(error)}`
+      );
+      if (attempt < maxAttempts - 1) {
+        await sleepFn(backoffFn(attempt));
+        continue;
+      }
+      throw lastError;
+    }
+
+    const status = resp.message.statusCode;
+    if (status !== HttpCodes.OK) {
+      lastError = new Error(
+        'failed fetching releases (' + status + ')'
+      );
+      if (RETRYABLE_STATUS_CODES.has(status) && attempt < maxAttempts - 1) {
+        await sleepFn(backoffFn(attempt));
+        continue;
+      }
+      throw lastError;
+    }
+
+    let body;
+    try {
+      body = await resp.readBody();
+    } catch (error) {
+      // Response body stream failure -- treat as transient.
+      lastError = new Error(
+        `Failed to read releases response: ${getErrorMessage(error)}`
+      );
+      if (attempt < maxAttempts - 1) {
+        await sleepFn(backoffFn(attempt));
+        continue;
+      }
+      throw lastError;
+    }
+
+    let releasesMeta;
+    try {
+      releasesMeta = JSON.parse(body);
+    } catch (error) {
+      // Malformed JSON is a permanent failure -- retrying won't help.
+      throw new Error(
+        `Invalid releases JSON from ${url}: ${getErrorMessage(error)}`
+      );
+    }
+
+    /**
+     * @type {Array}
+     */
+    const versions = releasesMeta.versions;
+
+    return versions.map((releaseMeta) => new Release(releaseMeta));
   }
 
-  if (resp.message.statusCode !== HttpCodes.OK) {
-    throw new Error(
-      'failed fetching releases (' + resp.message.statusCode + ')'
-    );
-  }
-
-  let body;
-  try {
-    body = await resp.readBody();
-  } catch (error) {
-    const cause = getErrorMessage(error);
-    throw new Error(`Failed to read releases response: ${cause}`);
-  }
-
-  let releasesMeta;
-  try {
-    releasesMeta = JSON.parse(body);
-  } catch (error) {
-    const cause = getErrorMessage(error);
-    throw new Error(`Invalid releases JSON from ${url}: ${cause}`);
-  }
-
-  /**
-   * @type {Array}
-   */
-  const versions = releasesMeta.versions;
-
-  return versions.map((releaseMeta) => new Release(releaseMeta));
+  // Loop can only exit via throw or return; this is defensive.
+  throw lastError || new Error('fetchReleases: exhausted retries with no outcome');
 }
 
 async function findLatestVersion (versions) {

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -29,12 +29,51 @@ class Release {
   }
 }
 
+const FETCH_RELEASES_MAX_ATTEMPTS = 4;
+const FETCH_RELEASES_BASE_DELAY_MS = 500;
+const FETCH_RELEASES_MAX_DELAY_MS = 8000;
+
+// Status codes that are worth retrying. Transient per GitHub's guidance
+// (https://docs.github.com/en/rest/overview/resources-in-the-rest-api#abuse-rate-limits)
+// and general HTTP semantics for 5xx / 408 Request Timeout / 429 Too Many Requests.
+const RETRYABLE_STATUS_CODES = new Set([
+  HttpCodes.RequestTimeout,
+  HttpCodes.TooManyRequests,
+  HttpCodes.InternalServerError,
+  HttpCodes.BadGateway,
+  HttpCodes.ServiceUnavailable,
+  HttpCodes.GatewayTimeout
+]);
+
+function _sleep (ms) {
+  return new Promise((resolve) => { setTimeout(resolve, ms); });
+}
+
+function _backoffDelayMs (attempt) {
+  // Exponential backoff: 500ms, 1s, 2s, 4s, ... capped at 8s, with jitter up to 250ms
+  // so multiple concurrent runners don't resync on the same retry boundary.
+  const exponential = Math.min(
+    FETCH_RELEASES_BASE_DELAY_MS * Math.pow(2, attempt),
+    FETCH_RELEASES_MAX_DELAY_MS
+  );
+  const jitter = Math.floor(Math.random() * 250);
+  return exponential + jitter;
+}
+
 /**
  * Fetches the top 30 releases sorted in desc order.
  *
+ * Retries transient failures (network errors, 408/429/5xx responses) with
+ * exponential backoff + jitter. Permanent failures (4xx other than 408/429,
+ * malformed JSON) fail fast on the first attempt.
+ *
  * @return {Array<Release>} Releases.
  */
-async function fetchReleases (githubToken) {
+async function fetchReleases (githubToken, {
+  maxAttempts = FETCH_RELEASES_MAX_ATTEMPTS,
+  sleepFn = _sleep,
+  backoffFn = _backoffDelayMs
+} = {}) {
   const userAgent = 'opentofu/setup-opentofu';
 
   const http = new HttpClient(userAgent);
@@ -45,42 +84,71 @@ async function fetchReleases (githubToken) {
     Accept: 'application/json'
   };
 
-  let resp;
-  try {
-    resp = await http.get(url, headers);
-  } catch (error) {
-    const cause = getErrorMessage(error);
-    throw new Error(`Failed to fetch OpenTofu releases from ${url}: ${cause}`);
+  let lastError;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    let resp;
+    try {
+      resp = await http.get(url, headers);
+    } catch (error) {
+      // Network-level failure -- always retryable; fall through to backoff.
+      lastError = new Error(
+        `Failed to fetch OpenTofu releases from ${url}: ${getErrorMessage(error)}`
+      );
+      if (attempt < maxAttempts - 1) {
+        await sleepFn(backoffFn(attempt));
+        continue;
+      }
+      throw lastError;
+    }
+
+    const status = resp.message.statusCode;
+    if (status !== HttpCodes.OK) {
+      lastError = new Error(
+        'failed fetching releases (' + status + ')'
+      );
+      if (RETRYABLE_STATUS_CODES.has(status) && attempt < maxAttempts - 1) {
+        await sleepFn(backoffFn(attempt));
+        continue;
+      }
+      throw lastError;
+    }
+
+    let body;
+    try {
+      body = await resp.readBody();
+    } catch (error) {
+      // Response body stream failure -- treat as transient.
+      lastError = new Error(
+        `Failed to read releases response: ${getErrorMessage(error)}`
+      );
+      if (attempt < maxAttempts - 1) {
+        await sleepFn(backoffFn(attempt));
+        continue;
+      }
+      throw lastError;
+    }
+
+    let releasesMeta;
+    try {
+      releasesMeta = JSON.parse(body);
+    } catch (error) {
+      // Malformed JSON is a permanent failure -- retrying won't help.
+      throw new Error(
+        `Invalid releases JSON from ${url}: ${getErrorMessage(error)}`
+      );
+    }
+
+    /**
+     * @type {Array}
+     */
+    const versions = releasesMeta.versions;
+
+    return versions.map((releaseMeta) => new Release(releaseMeta));
   }
 
-  if (resp.message.statusCode !== HttpCodes.OK) {
-    throw new Error(
-      'failed fetching releases (' + resp.message.statusCode + ')'
-    );
-  }
-
-  let body;
-  try {
-    body = await resp.readBody();
-  } catch (error) {
-    const cause = getErrorMessage(error);
-    throw new Error(`Failed to read releases response: ${cause}`);
-  }
-
-  let releasesMeta;
-  try {
-    releasesMeta = JSON.parse(body);
-  } catch (error) {
-    const cause = getErrorMessage(error);
-    throw new Error(`Invalid releases JSON from ${url}: ${cause}`);
-  }
-
-  /**
-   * @type {Array}
-   */
-  const versions = releasesMeta.versions;
-
-  return versions.map((releaseMeta) => new Release(releaseMeta));
+  // Loop can only exit via throw or return; this is defensive.
+  throw lastError || new Error('fetchReleases: exhausted retries with no outcome');
 }
 
 async function findLatestVersion (versions) {
@@ -145,4 +213,4 @@ async function getRelease (
   return releases.find((release) => release.version === versionSelected);
 }
 
-export { getRelease, Release };
+export { getRelease, Release, fetchReleases };

--- a/lib/test/releases-fetch.test.js
+++ b/lib/test/releases-fetch.test.js
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * Copyright (c) OpenTofu
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { jest } from '@jest/globals';
+
+// Mock @actions/http-client BEFORE importing releases so HttpClient is a mock
+jest.unstable_mockModule('@actions/http-client', () => {
+  const HttpCodes = {
+    OK: 200,
+    RequestTimeout: 408,
+    TooManyRequests: 429,
+    InternalServerError: 500,
+    BadGateway: 502,
+    ServiceUnavailable: 503,
+    GatewayTimeout: 504
+  };
+  class MockHttpClient {
+    async get () {
+      return MockHttpClient.__next();
+    }
+  }
+  MockHttpClient.__responses = [];
+  MockHttpClient.__next = () => {
+    const r = MockHttpClient.__responses.shift();
+    if (!r) throw new Error('Mock exhausted -- add another response');
+    if (r instanceof Error) throw r;
+    return r;
+  };
+  MockHttpClient.__reset = () => { MockHttpClient.__responses = []; };
+  MockHttpClient.__enqueue = (r) => { MockHttpClient.__responses.push(r); };
+  return { HttpClient: MockHttpClient, HttpCodes };
+});
+
+const { fetchReleases } = await import('../releases.js');
+const { HttpClient } = await import('@actions/http-client');
+
+function okBody (versions) {
+  return {
+    message: { statusCode: 200 },
+    readBody: async () => JSON.stringify({ versions })
+  };
+}
+
+function errBody (status) {
+  return {
+    message: { statusCode: status },
+    readBody: async () => ''
+  };
+}
+
+const sampleVersions = [
+  { id: 'v1.9.0', files: ['tofu_1.9.0_linux_amd64.zip'] }
+];
+
+describe('fetchReleases retry/backoff', () => {
+  beforeEach(() => {
+    HttpClient.__reset();
+  });
+
+  test('succeeds on first attempt without retry', async () => {
+    HttpClient.__enqueue(okBody(sampleVersions));
+    const sleepFn = jest.fn(async () => {});
+    const backoffFn = jest.fn(() => 0);
+    const releases = await fetchReleases(undefined, { sleepFn, backoffFn });
+    expect(releases).toHaveLength(1);
+    expect(releases[0].version).toBe('1.9.0');
+    expect(sleepFn).not.toHaveBeenCalled();
+  });
+
+  test('retries on 503 then succeeds', async () => {
+    HttpClient.__enqueue(errBody(503));
+    HttpClient.__enqueue(errBody(503));
+    HttpClient.__enqueue(okBody(sampleVersions));
+    const sleepFn = jest.fn(async () => {});
+    const backoffFn = jest.fn(() => 0);
+    const releases = await fetchReleases(undefined, { sleepFn, backoffFn });
+    expect(releases).toHaveLength(1);
+    expect(sleepFn).toHaveBeenCalledTimes(2);
+    expect(backoffFn).toHaveBeenCalledWith(0);
+    expect(backoffFn).toHaveBeenCalledWith(1);
+  });
+
+  test('retries on 429 (rate-limit)', async () => {
+    HttpClient.__enqueue(errBody(429));
+    HttpClient.__enqueue(okBody(sampleVersions));
+    const sleepFn = jest.fn(async () => {});
+    const backoffFn = jest.fn(() => 0);
+    const releases = await fetchReleases(undefined, { sleepFn, backoffFn });
+    expect(releases).toHaveLength(1);
+    expect(sleepFn).toHaveBeenCalledTimes(1);
+  });
+
+  test('retries on network error (thrown from http.get)', async () => {
+    HttpClient.__enqueue(new Error('ECONNRESET'));
+    HttpClient.__enqueue(okBody(sampleVersions));
+    const sleepFn = jest.fn(async () => {});
+    const backoffFn = jest.fn(() => 0);
+    const releases = await fetchReleases(undefined, { sleepFn, backoffFn });
+    expect(releases).toHaveLength(1);
+    expect(sleepFn).toHaveBeenCalledTimes(1);
+  });
+
+  test('does NOT retry on 404 (permanent failure)', async () => {
+    HttpClient.__enqueue(errBody(404));
+    const sleepFn = jest.fn(async () => {});
+    await expect(
+      fetchReleases(undefined, { sleepFn, backoffFn: () => 0 })
+    ).rejects.toThrow('failed fetching releases (404)');
+    expect(sleepFn).not.toHaveBeenCalled();
+  });
+
+  test('does NOT retry on malformed JSON (permanent failure)', async () => {
+    HttpClient.__enqueue({
+      message: { statusCode: 200 },
+      readBody: async () => '{not json'
+    });
+    const sleepFn = jest.fn(async () => {});
+    await expect(
+      fetchReleases(undefined, { sleepFn, backoffFn: () => 0 })
+    ).rejects.toThrow(/Invalid releases JSON/);
+    expect(sleepFn).not.toHaveBeenCalled();
+  });
+
+  test('gives up after maxAttempts and throws last error', async () => {
+    HttpClient.__enqueue(errBody(503));
+    HttpClient.__enqueue(errBody(503));
+    HttpClient.__enqueue(errBody(503));
+    const sleepFn = jest.fn(async () => {});
+    await expect(
+      fetchReleases(undefined, { maxAttempts: 3, sleepFn, backoffFn: () => 0 })
+    ).rejects.toThrow('failed fetching releases (503)');
+    expect(sleepFn).toHaveBeenCalledTimes(2); // 2 sleeps between 3 attempts
+  });
+});


### PR DESCRIPTION
## Summary

`fetchReleases()` in `lib/releases.js` made a single GET to `https://get.opentofu.org/tofu/api.json` and threw on any failure -- network error, HTTP 429, or any 5xx. Action runs would fail whenever the releases endpoint hiccuped. Wrap the fetch in an exponential-backoff retry loop so transient failures self-heal. Addresses #110.

## Why

Per the issue thread, @diofeher marked this `accepted` and said:

> The "rate-limiting" part is indeed true. While interacting with this API, we don't handle it. I'm going to put this issue as accepted so retry and back-off can be implemented.

Today the fetch path has three failure modes, all treated as permanent:

1. `http.get(...)` throws (network reset, DNS, TLS) -> rethrown with no retry.
2. Response with non-200 status -> rethrown with no retry.
3. `resp.readBody()` throws mid-stream -> rethrown with no retry.

On shared CI, all three are frequently transient. A single retry with jitter would paper over the vast majority without changing steady-state behavior for callers.

## Changes

Only `lib/releases.js` grows logic; interfaces are unchanged.

- New private helpers:
  - `_sleep(ms)` -- promisified `setTimeout`.
  - `_backoffDelayMs(attempt)` -- exponential (500ms, 1s, 2s, ...) capped at 8s with up to 250ms jitter so concurrent runners don't resync on retry boundaries.
- `fetchReleases` now loops up to `maxAttempts` (default `4`):
  - Network-level throws from `http.get` -> sleep + retry until exhausted.
  - 200 response -> return as before.
  - 408 / 429 / 500 / 502 / 503 / 504 -> sleep + retry.
  - Other 4xx -> fail fast (unchanged).
  - `readBody` throws -> sleep + retry (treated as transient stream failure).
  - `JSON.parse` throws -> fail fast (retrying won't help malformed JSON).
- `maxAttempts`, `sleepFn`, `backoffFn` are second-arg options, default to the production values. Tests inject a no-op `sleepFn` to keep the suite instant.
- `fetchReleases` added to the named exports so tests can drive it directly.

The retry path is gated on status codes that the [HTTP spec and GitHub's guidance](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#abuse-rate-limits) call out as transient. Every other `4xx` still fails on the first attempt; callers see the same error as before.

## Testing

New `lib/test/releases-fetch.test.js` covers:

- Success on first attempt -> no sleep calls.
- 503 -> 503 -> 200 -> succeeds, sleeps twice with expected `attempt` values (`0`, `1`).
- 429 (rate-limit) -> 200 -> succeeds.
- Network error thrown from `http.get` -> retry -> success.
- 404 -> fails fast with no sleep (permanent).
- Malformed JSON -> fails fast with no sleep (permanent).
- `maxAttempts=3` exhausted on three 503s -> throws last error, sleeps 2 times (between attempts 1-2 and 2-3).

Existing suites untouched: `npm test` reports `5 passed, 5 total` / `41 tests`. `npm run build` produces `dist/` bundle; committed alongside the source change since this action ships prebuilt.

Fixes #110

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
