### PR TITLE
feat: parse .tool-versions (asdf format) in tofu_version_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ steps:
       tofu_version_file: .opentofu-version
 ```
 
+`tofu_version_file` accepts two formats:
+
+- A single-line file with just the version (e.g., `.opentofu-version` containing `1.12.0`).
+- An asdf-format `.tool-versions` file containing an `opentofu <version>` line — other tool entries in the same file are ignored.
+
 Supported version syntax is the same as for the `tofu_version` input. If both `tofu_version` and `tofu_version_file` are provided, the version number in the file takes precedence.
 
 Credentials for Terraform Cloud ([app.terraform.io](https://app.terraform.io/)) can be configured:

--- a/dist/index.js
+++ b/dist/index.js
@@ -34886,9 +34886,12 @@ async function run () {
       try {
         core_debug(`Reading OpenTofu version from file: ${versionFile}`);
         const fileVersion = await external_fs_namespaceObject.promises.readFile(versionFile, 'utf8');
-        const trimmedVersion = fileVersion.trim();
-        if (trimmedVersion) {
-          version = trimmedVersion;
+        // .tool-versions (asdf format): take the version from the `opentofu <version>` line.
+        // Otherwise (e.g. a single-line `.opentofu-version`): use the whole trimmed file content.
+        const asdfMatch = fileVersion.match(/^\s*opentofu\s+([^\s#]+)/m);
+        const parsedVersion = asdfMatch ? asdfMatch[1] : fileVersion.trim();
+        if (parsedVersion) {
+          version = parsedVersion;
           core_debug(`Using version from file: ${version}`);
         } else {
           warning(

--- a/lib/setup-tofu.js
+++ b/lib/setup-tofu.js
@@ -195,9 +195,12 @@ async function run () {
       try {
         debug(`Reading OpenTofu version from file: ${versionFile}`);
         const fileVersion = await fs.readFile(versionFile, 'utf8');
-        const trimmedVersion = fileVersion.trim();
-        if (trimmedVersion) {
-          version = trimmedVersion;
+        // .tool-versions (asdf format): take the version from the `opentofu <version>` line.
+        // Otherwise (e.g. a single-line `.opentofu-version`): use the whole trimmed file content.
+        const asdfMatch = fileVersion.match(/^\s*opentofu\s+([^\s#]+)/m);
+        const parsedVersion = asdfMatch ? asdfMatch[1] : fileVersion.trim();
+        if (parsedVersion) {
+          version = parsedVersion;
           debug(`Using version from file: ${version}`);
         } else {
           warning(

--- a/lib/test/setup-tofu.test.js
+++ b/lib/test/setup-tofu.test.js
@@ -217,6 +217,33 @@ describe('setup-tofu', () => {
 
       expect(fs.readFile).not.toHaveBeenCalled();
     });
+
+    it('should parse opentofu version from .tool-versions (asdf format)', async () => {
+      jest.spyOn(fs, 'readFile');
+
+      const asdfVersion = '1.12.0';
+      const asdfFile = join(tempDir, '.tool-versions');
+      await fs.writeFile(asdfFile, `nodejs 24\nopentofu ${asdfVersion}\n`);
+
+      getInput.mockImplementation((name) => {
+        if (name === 'tofu_version_file') {
+          return asdfFile;
+        }
+        if (name === 'tofu_version') {
+          return fallbackVersion;
+        }
+        return '';
+      });
+
+      await setup();
+
+      expect(getRelease).toHaveBeenCalledWith(
+        asdfVersion,
+        process.env.GITHUB_TOKEN
+      );
+
+      expect(fs.readFile).toHaveBeenCalled();
+    });
   });
 
   describe('caching functionality', () => {


### PR DESCRIPTION
Adds asdf-format `.tool-versions` parsing to the existing `tofu_version_file` input. Single-line files (e.g. `.opentofu-version`) continue to work unchanged — behavior is backwards-compatible.

## Why

Monorepos commonly pin multiple tool versions in a single `.tool-versions` file (asdf, mise, rtx all read this format). Today, this action's `tofu_version_file` only handles single-tool files, forcing repos that already maintain a `.tool-versions` to keep a separate `.opentofu-version` in sync. Drift between the two is silent and version-skew is a common workflow regression.

The same input shape — "give me a file, I'll figure out the version" — is already supported by sibling actions:

- [`actions/setup-node`](https://github.com/actions/setup-node) via `node-version-file: .tool-versions` (parses the `nodejs <version>` line)
- [`actions/setup-python`](https://github.com/actions/setup-python) via `python-version-file: .tool-versions` (parses the `python <version>` line)

## What changed

- `lib/setup-tofu.js` — existing `tofu_version_file` block now tries an asdf-format match first (`/^\s*opentofu\s+([^\s#]+)/m`); if no match, falls back to the previous "trim the whole file" behavior.
- `lib/test/setup-tofu.test.js` — added a test for the `.tool-versions` asdf format. All 14 tests pass (13 existing, 1 new).
- `README.md` — `tofu_version_file` example section now documents both file formats.

Behavior matrix:

| File                                            | Before                                       | After                       |
|-------------------------------------------------|----------------------------------------------|-----------------------------|
| `.opentofu-version` containing `1.12.0`         | ✓                                            | ✓ (unchanged path)          |
| `.tool-versions` with one line `opentofu 1.12.0`| ✗ uses `"opentofu 1.12.0"` as version        | ✓ parses `1.12.0`           |
| `.tool-versions` with `nodejs 24\nopentofu 1.12.0` | ✗ uses the whole multi-line as version    | ✓ parses `1.12.0`           |
| Empty file                                      | warning (unchanged)                          | warning (unchanged)         |
| Missing file                                    | warning (unchanged)                          | warning (unchanged)         |

Comments and trailing whitespace on the `opentofu` line are tolerated (`[^\s#]+`).
