### PR TITLE
feat: support .tool-versions (asdf format) in tofu_version_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ steps:
       tofu_version_file: .opentofu-version
 ```
 
+`tofu_version_file` accepts two formats:
+
+- A single-line file containing just the version (e.g., `.opentofu-version` with `1.9.0`).
+- An asdf-format `.tool-versions` file containing an `opentofu <version>` line. Other tool entries in the same file are ignored.
+
 Supported version syntax is the same as for the `tofu_version` input. If both `tofu_version` and `tofu_version_file` are provided, the version number in the file takes precedence.
 
 Credentials for Terraform Cloud ([app.terraform.io](https://app.terraform.io/)) can be configured:

--- a/dist/index.js
+++ b/dist/index.js
@@ -35234,9 +35234,13 @@ async function run () {
       try {
         core_debug(`Reading OpenTofu version from file: ${versionFile}`);
         const fileVersion = await external_fs_namespaceObject.promises.readFile(versionFile, 'utf8');
-        const trimmedVersion = fileVersion.trim();
-        if (trimmedVersion) {
-          version = trimmedVersion;
+        // .tool-versions (asdf format): use the version from the `opentofu <version>`
+        // line and ignore other tool entries. Otherwise (e.g. a single-line
+        // `.opentofu-version` file): use the whole trimmed file content.
+        const asdfMatch = fileVersion.match(/^\s*opentofu\s+([^\s#]+)/m);
+        const parsedVersion = asdfMatch ? asdfMatch[1] : fileVersion.trim();
+        if (parsedVersion) {
+          version = parsedVersion;
           core_debug(`Using version from file: ${version}`);
         } else {
           warning(

--- a/dist/index.js
+++ b/dist/index.js
@@ -35237,6 +35237,7 @@ async function run () {
         // .tool-versions (asdf format): use the version from the `opentofu <version>`
         // line and ignore other tool entries. Otherwise (e.g. a single-line
         // `.opentofu-version` file): use the whole trimmed file content.
+        // Spec: https://asdf-vm.com/manage/configuration.html#tool-versions
         const asdfMatch = fileVersion.match(/^\s*opentofu\s+([^\s#]+)/m);
         const parsedVersion = asdfMatch ? asdfMatch[1] : fileVersion.trim();
         if (parsedVersion) {

--- a/lib/setup-tofu.js
+++ b/lib/setup-tofu.js
@@ -231,9 +231,13 @@ async function run () {
       try {
         debug(`Reading OpenTofu version from file: ${versionFile}`);
         const fileVersion = await fs.readFile(versionFile, 'utf8');
-        const trimmedVersion = fileVersion.trim();
-        if (trimmedVersion) {
-          version = trimmedVersion;
+        // .tool-versions (asdf format): use the version from the `opentofu <version>`
+        // line and ignore other tool entries. Otherwise (e.g. a single-line
+        // `.opentofu-version` file): use the whole trimmed file content.
+        const asdfMatch = fileVersion.match(/^\s*opentofu\s+([^\s#]+)/m);
+        const parsedVersion = asdfMatch ? asdfMatch[1] : fileVersion.trim();
+        if (parsedVersion) {
+          version = parsedVersion;
           debug(`Using version from file: ${version}`);
         } else {
           warning(

--- a/lib/setup-tofu.js
+++ b/lib/setup-tofu.js
@@ -234,6 +234,7 @@ async function run () {
         // .tool-versions (asdf format): use the version from the `opentofu <version>`
         // line and ignore other tool entries. Otherwise (e.g. a single-line
         // `.opentofu-version` file): use the whole trimmed file content.
+        // Spec: https://asdf-vm.com/manage/configuration.html#tool-versions
         const asdfMatch = fileVersion.match(/^\s*opentofu\s+([^\s#]+)/m);
         const parsedVersion = asdfMatch ? asdfMatch[1] : fileVersion.trim();
         if (parsedVersion) {

--- a/lib/test/setup-tofu.test.js
+++ b/lib/test/setup-tofu.test.js
@@ -225,6 +225,34 @@ describe('setup-tofu', () => {
 
       expect(fs.readFile).not.toHaveBeenCalled();
     });
+
+    it('should parse the opentofu version from a .tool-versions (asdf) file', async () => {
+      jest.spyOn(fs, 'readFile');
+
+      const asdfVersion = '1.9.0';
+      versionFileName = '.tool-versions';
+      versionFile = join(tempDir, versionFileName);
+      await fs.writeFile(versionFile, `nodejs 24.14.0\nopentofu ${asdfVersion}\nterraform 1.5.0\n`);
+
+      getInput.mockImplementation((name) => {
+        if (name === 'tofu_version_file') {
+          return versionFile;
+        }
+        if (name === 'tofu_version') {
+          return fallbackVersion;
+        }
+        return '';
+      });
+
+      await setup();
+
+      expect(getRelease).toHaveBeenCalledWith(
+        asdfVersion,
+        process.env.GITHUB_TOKEN
+      );
+
+      expect(fs.readFile).toHaveBeenCalled();
+    });
   });
 
   describe('caching functionality', () => {


### PR DESCRIPTION
Extends the existing `tofu_version_file` input to also accept an asdf-format `.tool-versions` file: the `opentofu <version>` line is used and other tool entries are ignored. A single-line `.opentofu-version` file keeps working unchanged (the parser falls back to the trimmed file content when no `opentofu` line is present).

This revives the minimal approach from the earlier #118, which was closed before the feature was accepted in #40.

Validation (local):
- `npm test`: semistandard lint clean, jest 43/43 pass (incl. a new `.tool-versions` test)
- `npm run build`: `dist/index.js` regenerated, diff limited to the parser change

closes: #40