### PR TITLE
Bump dependency to fix security issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -699,9 +699,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+			"integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
 			"dev": true,
 			"funding": [
 				{
@@ -3649,9 +3649,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/js-yaml": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+			"integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
 			"dev": true,
 			"funding": [
 				{


### PR DESCRIPTION
Due to https://github.com/advisories/GHSA-2883-xcg3-v3hh reported on https://github.com/nodeca/js-yaml upgraded the dependency from 4.3.1 to 4.3.2 ([changelog](https://github.com/nodeca/js-yaml/blob/v4/CHANGELOG.md#432---2026-08-26)).
